### PR TITLE
Update dependabot target branch for PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,4 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    target-branch: "deps"


### PR DESCRIPTION
Changing this to avoid triggering multiple deploys on Netlify because of the quantity of dependencies updates.